### PR TITLE
Add user guide and demo

### DIFF
--- a/CODE_CHANGE_CHECKLIST.md
+++ b/CODE_CHANGE_CHECKLIST.md
@@ -1,0 +1,7 @@
+# Code Change Checklist
+
+- [ ] Documentation updated
+- [ ] Unit tests added/updated
+- [ ] Demo scripts updated
+- [ ] Poetry lock file updated if dependencies changed
+- [ ] `pytest` passes

--- a/README.md
+++ b/README.md
@@ -1,6 +1,8 @@
 # Data Validator
 
 A flexible data validation module that uses YAML configuration to apply data quality rules against Spark DataFrames in Delta Live Tables. The module supports multiple compute engines including PySpark, DuckDB, and Polars, and integrates with Databricks labs DQX package.
+For a step-by-step guide, see [docs/user_guide.md](docs/user_guide.md).
+
 
 ## Features
 

--- a/docs/user_guide.md
+++ b/docs/user_guide.md
@@ -1,0 +1,97 @@
+# Data Validator User Guide
+
+This guide provides a quick introduction to the `data_validator` package. All functionality is configuration driven through YAML files. Examples below demonstrate how to create configurations and execute validations using different compute engines.
+
+## Installation with Poetry
+
+```bash
+poetry install
+```
+
+To run the examples in this repository use Poetry's run command:
+
+```bash
+poetry run python examples/demo_validation.py
+```
+
+## Example YAML Configuration
+
+```yaml
+version: "1.0"
+engine:
+  type: "duckdb"
+  connection_params:
+    database: ":memory:"
+tables:
+  - name: "users"
+    rules:
+      - name: "id_completeness"
+        rule_type: "completeness"
+        column: "id"
+        severity: "error"
+      - name: "email_format"
+        rule_type: "pattern"
+        column: "email"
+        parameters:
+          pattern: "^[a-zA-Z0-9._%+-]+@[a-zA-Z0-9.-]+\\.[a-zA-Z]{2,}$"
+        threshold: 0.8
+        severity: "warning"
+      - name: "age_range"
+        rule_type: "range"
+        column: "age"
+        parameters:
+          min_value: 0
+          max_value: 120
+        threshold: 0.9
+        severity: "error"
+```
+
+Save the above as `demo_config.yaml` and use it with the `DataValidator` as shown below.
+
+## Basic Usage
+
+```python
+from data_validator import DataValidator
+import pandas as pd
+
+# Load configuration from YAML
+validator = DataValidator("demo_config.yaml")
+
+# Create sample data
+data = pd.DataFrame({
+    "id": [1, 2, 3, None, 5],
+    "email": ["a@example.com", "invalid", "c@example.com", "d@example.com", None],
+    "age": [25, 130, 35, 40, 28],
+})
+
+# Run validation and generate report
+summary = validator.validate_table(data, "users")
+report = validator.get_validation_report(summary)
+print(report)
+```
+
+## Template Code Blocks
+
+### Validate Multiple Tables
+
+```python
+sources = {
+    "users": users_df,
+    "orders": orders_df,
+}
+results = validator.validate_all_tables(sources)
+```
+
+### Apply Filters
+
+```python
+clean_df = validator.apply_filters(data, "users")
+```
+
+### Generate Validation Report
+
+```python
+report = validator.get_validation_report(summary)
+```
+
+For more examples see the `examples/` directory.

--- a/examples/demo_config.yaml
+++ b/examples/demo_config.yaml
@@ -1,0 +1,27 @@
+version: "1.0"
+engine:
+  type: "duckdb"
+  connection_params:
+    database: ":memory:"
+tables:
+  - name: "users"
+    rules:
+      - name: "id_completeness"
+        rule_type: "completeness"
+        column: "id"
+        severity: "error"
+      - name: "email_format"
+        rule_type: "pattern"
+        column: "email"
+        parameters:
+          pattern: "^[a-zA-Z0-9._%+-]+@[a-zA-Z0-9.-]+\\.[a-zA-Z]{2,}$"
+        threshold: 0.8
+        severity: "warning"
+      - name: "age_range"
+        rule_type: "range"
+        column: "age"
+        parameters:
+          min_value: 0
+          max_value: 120
+        threshold: 0.9
+        severity: "error"

--- a/examples/demo_validation.py
+++ b/examples/demo_validation.py
@@ -1,0 +1,35 @@
+"""Demonstration script for the data_validator package.
+
+This script loads configuration from ``demo_config.yaml`` and validates a
+sample Pandas DataFrame. It prints a short summary and returns the
+``ValidationSummary`` instance for programmatic use.
+"""
+from pathlib import Path
+import pandas as pd
+
+from data_validator import DataValidator
+
+
+DATA = pd.DataFrame(
+    {
+        "id": [1, 2, 3, None, 5],
+        "email": ["a@example.com", "invalid", "c@example.com", "d@example.com", None],
+        "age": [25, 130, 35, 40, 28],
+    }
+)
+
+
+def run_demo() -> "data_validator.engines.ValidationSummary":
+    """Execute the demo validation run."""
+    config_path = Path(__file__).parent / "demo_config.yaml"
+    validator = DataValidator(config_path)
+    summary = validator.validate_table(DATA, "users")
+    report = validator.get_validation_report(summary)
+    print(
+        f"Validation success rate: {report['overall_stats']['overall_success_rate']:.1%}"
+    )
+    return summary
+
+
+if __name__ == "__main__":
+    run_demo()

--- a/examples/demo_validation.py
+++ b/examples/demo_validation.py
@@ -19,7 +19,7 @@ DATA = pd.DataFrame(
 )
 
 
-def run_demo() -> "data_validator.engines.ValidationSummary":
+def run_demo() -> ValidationSummary:
     """Execute the demo validation run."""
     config_path = Path(__file__).parent / "demo_config.yaml"
     validator = DataValidator(config_path)

--- a/tests/test_demo_script.py
+++ b/tests/test_demo_script.py
@@ -1,0 +1,7 @@
+from examples.demo_validation import run_demo
+
+
+def test_run_demo():
+    summary = run_demo()
+    assert summary.table_name == "users"
+    assert summary.total_rules == 3


### PR DESCRIPTION
## Summary
- add user guide with example configuration and usage
- provide demo script and configuration
- include a code change checklist for contributors
- document the user guide in the main README
- test demo script

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687caef2ba248326bbf3b21b40004e90