### PR TITLE
Add configurable settings loader with env overrides

### DIFF
--- a/CHECKLIST.md
+++ b/CHECKLIST.md
@@ -5,3 +5,7 @@
 - [x] Update documentation with instructions
 - [x] Provide poetry configuration and CLI entrypoint
 - [x] Add unit tests for new functionality
+- [ ] Implement YAML/env based configuration loader
+- [ ] Support env var overrides via Pydantic settings
+- [ ] Merge config from Databricks widgets
+- [ ] Add demo script and documentation

--- a/README.md
+++ b/README.md
@@ -89,6 +89,23 @@ print(f"Success rate: {summary.overall_success_rate:.2%}")
 clean_df = validator.apply_filters(df, "customers")
 ```
 
+### 4. Environment Overrides and Widgets
+
+Configuration values can be overridden using environment variables or Databricks
+widgets when running on Databricks. Environment variable names mirror the YAML
+structure using double underscores. For example:
+
+```bash
+export VALIDATOR_ENGINE__TYPE=duckdb
+export VALIDATOR_DQX__ENABLED=false
+```
+
+You can also provide a widget named `engine` in Databricks to override the
+engine type.
+
+See [docs/config_merge.md](docs/config_merge.md) for more examples.
+
+
 ## Configuration Reference
 
 ### Engine Configuration

--- a/docs/config_merge.md
+++ b/docs/config_merge.md
@@ -1,0 +1,24 @@
+# Configuration Merging
+
+This project supports loading configuration from YAML files with optional overrides from environment variables and Databricks widgets.
+
+## Usage
+
+1. Create a YAML configuration file as normal.
+2. Optionally set environment variables prefixed with `VALIDATOR_` to override settings. Nested values use double underscores:
+   ```bash
+   export VALIDATOR_ENGINE__TYPE=duckdb
+   export VALIDATOR_DQX__ENABLED=false
+   ```
+3. When running on Databricks notebooks, widgets named `config` or `engine` can be used to supply a configuration path or engine override.
+
+The helper function `data_validator.settings.load_config()` returns a merged `ValidationConfig` instance combining these sources. `DataValidator` automatically uses this loader when given a YAML path.
+
+## Example
+
+```python
+from data_validator.settings import load_config
+
+config = load_config("config.yaml")  # env vars and widgets are merged automatically
+validator = DataValidator(config)
+```

--- a/examples/config_merge_demo.py
+++ b/examples/config_merge_demo.py
@@ -1,0 +1,26 @@
+"""Demo showing configuration merging from YAML, environment variables, and Databricks widgets."""
+
+import os
+from pathlib import Path
+
+from data_validator.settings import load_config
+from data_validator import DataValidator
+
+HERE = Path(__file__).parent
+CONFIG_PATH = HERE / "sample_config.yaml"
+
+
+def main() -> None:
+    """Load configuration from multiple sources and run a simple validation."""
+    # Override the engine type using an environment variable
+    os.environ["VALIDATOR_ENGINE__TYPE"] = "duckdb"
+
+    config = load_config(str(CONFIG_PATH))
+    print(f"Merged engine type: {config.engine.type}")
+
+    validator = DataValidator(config)
+    print(f"Loaded {len(validator.config.tables)} table configurations")
+
+
+if __name__ == "__main__":
+    main()

--- a/src/data_validator/engines/databricks_engine.py
+++ b/src/data_validator/engines/databricks_engine.py
@@ -3,7 +3,7 @@ Databricks validation engine implementation.
 
 This engine extends the PySpark engine with Databricks-specific features including:
 - Databricks workspace integration
-- Unity Catalog support  
+- Unity Catalog support
 - Databricks widgets and job parameters
 - Databricks authentication and secrets management
 - Integration with Databricks monitoring and logging
@@ -17,6 +17,7 @@ from pathlib import Path
 try:
     from pyspark.sql import SparkSession, DataFrame
     from pyspark.sql.functions import col, count, sum as spark_sum, when, isnan, isnull
+
     PYSPARK_AVAILABLE = True
 except ImportError:
     PYSPARK_AVAILABLE = False
@@ -26,6 +27,7 @@ except ImportError:
 try:
     # Try to import Databricks-specific utilities
     from pyspark.dbutils import DBUtils
+
     DBUTILS_AVAILABLE = True
 except ImportError:
     DBUTILS_AVAILABLE = False
@@ -38,23 +40,25 @@ from ..config import ValidationRule, EngineConfig
 
 class DatabricksValidationEngine(PySparkValidationEngine):
     """Databricks implementation of validation engine that extends PySpark engine."""
-    
+
     def __init__(self, config: EngineConfig):
         if not PYSPARK_AVAILABLE:
-            raise ImportError("PySpark is not available. Install with: pip install pyspark")
-        
+            raise ImportError(
+                "PySpark is not available. Install with: pip install pyspark"
+            )
+
         super().__init__(config)
         self._dbutils: Optional[Any] = None
         self._databricks_runtime = self._detect_databricks_runtime()
-        
+
     def _detect_databricks_runtime(self) -> bool:
         """Detect if running in Databricks runtime environment."""
         return (
-            os.environ.get('DATABRICKS_RUNTIME_VERSION') is not None or
-            os.path.exists('/databricks/spark/conf/spark-defaults.conf') or
-            'databricks' in os.environ.get('SPARK_HOME', '').lower()
+            os.environ.get("DATABRICKS_RUNTIME_VERSION") is not None
+            or os.path.exists("/databricks/spark/conf/spark-defaults.conf")
+            or "databricks" in os.environ.get("SPARK_HOME", "").lower()
         )
-    
+
     def connect(self) -> None:
         """Establish Spark session with Databricks-specific configuration."""
         if self._spark is None:
@@ -63,39 +67,45 @@ class DatabricksValidationEngine(PySparkValidationEngine):
                 try:
                     self._spark = SparkSession.getActiveSession()
                     if self._spark is None:
-                        self._spark = SparkSession.builder.appName("DataValidator-Databricks").getOrCreate()
+                        self._spark = SparkSession.builder.appName(
+                            "DataValidator-Databricks"
+                        ).getOrCreate()
                 except Exception:
                     # Fallback to creating new session
-                    self._spark = SparkSession.builder.appName("DataValidator-Databricks").getOrCreate()
+                    self._spark = SparkSession.builder.appName(
+                        "DataValidator-Databricks"
+                    ).getOrCreate()
             else:
                 # Create Spark session with Databricks Connect configuration
                 builder = SparkSession.builder.appName("DataValidator-Databricks")
-                
+
                 # Apply Databricks-specific connection parameters
                 for key, value in self.config.connection_params.items():
                     builder = builder.config(key, value)
-                
+
                 # Apply additional options
                 for key, value in self.config.options.items():
                     builder = builder.config(key, value)
-                
+
                 self._spark = builder.getOrCreate()
-            
+
             # Initialize dbutils if available
             self._init_dbutils()
-    
+
     def _init_dbutils(self) -> None:
         """Initialize Databricks utilities."""
         try:
             if self._databricks_runtime and self._spark:
                 # In Databricks runtime, dbutils is available through SparkContext
-                self._dbutils = self._spark.sparkContext._jvm.com.databricks.service.DBUtils
+                self._dbutils = (
+                    self._spark.sparkContext._jvm.com.databricks.service.DBUtils
+                )
             else:
                 # For Databricks Connect, dbutils might not be available
                 self._dbutils = None
         except Exception:
             self._dbutils = None
-    
+
     def get_widget_value(self, widget_name: str, default_value: str = "") -> str:
         """Get value from Databricks widget."""
         if self._dbutils and self._databricks_runtime:
@@ -105,8 +115,10 @@ class DatabricksValidationEngine(PySparkValidationEngine):
                 return default_value
         else:
             # Fallback to environment variables for non-Databricks environments
-            return os.environ.get(f"DATABRICKS_WIDGET_{widget_name.upper()}", default_value)
-    
+            return os.environ.get(
+                f"DATABRICKS_WIDGET_{widget_name.upper()}", default_value
+            )
+
     def get_secret(self, scope: str, key: str) -> Optional[str]:
         """Get secret from Databricks secret scope."""
         if self._dbutils and self._databricks_runtime:
@@ -116,9 +128,10 @@ class DatabricksValidationEngine(PySparkValidationEngine):
                 return None
         else:
             # Fallback to environment variables for testing/development
-            env_key = f"DATABRICKS_SECRET_{scope.upper()}_{key.upper()}"
+            sanitized_key = key.upper().replace("-", "_")
+            env_key = f"DATABRICKS_SECRET_{scope.upper()}_{sanitized_key}"
             return os.environ.get(env_key)
-    
+
     def load_data(self, source: Union[str, DataFrame, Dict[str, Any]]) -> DataFrame:
         """Load data from source with Databricks-specific enhancements."""
         if isinstance(source, DataFrame):
@@ -142,11 +155,11 @@ class DatabricksValidationEngine(PySparkValidationEngine):
                 return super().load_data(source)
         else:
             raise ValueError(f"Unsupported source type: {type(source)}")
-    
+
     def _load_from_databricks_source(self, source_config: Dict[str, Any]) -> DataFrame:
         """Load data from Databricks-specific source configuration."""
         source_type = source_config.get("type", "table")
-        
+
         if source_type == "unity_catalog":
             catalog = source_config.get("catalog")
             schema = source_config.get("schema")
@@ -155,15 +168,17 @@ class DatabricksValidationEngine(PySparkValidationEngine):
                 table_name = f"{catalog}.{schema}.{table}"
                 return self._spark.table(table_name)
             else:
-                raise ValueError("Unity Catalog source requires catalog, schema, and table")
-        
+                raise ValueError(
+                    "Unity Catalog source requires catalog, schema, and table"
+                )
+
         elif source_type == "delta":
             path = source_config.get("path")
             if path:
                 return self._spark.read.format("delta").load(path)
             else:
                 raise ValueError("Delta source requires path")
-        
+
         elif source_type == "volume":
             # Unity Catalog Volume
             catalog = source_config.get("catalog")
@@ -173,13 +188,19 @@ class DatabricksValidationEngine(PySparkValidationEngine):
             if catalog and schema and volume and file_path:
                 volume_path = f"/Volumes/{catalog}/{schema}/{volume}/{file_path}"
                 format_type = source_config.get("format", "csv")
-                return self._spark.read.format(format_type).option("header", "true").load(volume_path)
+                return (
+                    self._spark.read.format(format_type)
+                    .option("header", "true")
+                    .load(volume_path)
+                )
             else:
-                raise ValueError("Volume source requires catalog, schema, volume, and file_path")
-        
+                raise ValueError(
+                    "Volume source requires catalog, schema, volume, and file_path"
+                )
+
         else:
             raise ValueError(f"Unsupported Databricks source type: {source_type}")
-    
+
     def _load_from_catalog(self, table_name: str) -> DataFrame:
         """Load data from Unity Catalog with enhanced error handling."""
         try:
@@ -192,15 +213,15 @@ class DatabricksValidationEngine(PySparkValidationEngine):
                 raise ValueError(error_msg)
             else:
                 raise e
-    
+
     def _get_available_catalogs(self) -> List[str]:
         """Get list of available catalogs."""
         try:
             catalogs_df = self._spark.sql("SHOW CATALOGS")
-            return [row['catalog'] for row in catalogs_df.collect()]
+            return [row["catalog"] for row in catalogs_df.collect()]
         except Exception:
             return ["Unable to retrieve catalogs"]
-    
+
     def execute_rule(self, data: DataFrame, rule: ValidationRule) -> ValidationResult:
         """Execute validation rule with Databricks-specific enhancements."""
         # Check if rule has Databricks-specific parameters
@@ -209,33 +230,35 @@ class DatabricksValidationEngine(PySparkValidationEngine):
         else:
             # Use parent class implementation
             return super().execute_rule(data, rule)
-    
-    def _execute_databricks_rule(self, data: DataFrame, rule: ValidationRule) -> ValidationResult:
+
+    def _execute_databricks_rule(
+        self, data: DataFrame, rule: ValidationRule
+    ) -> ValidationResult:
         """Execute Databricks-specific validation rules."""
         start_time = time.time()
         databricks_params = rule.parameters.get("databricks", {})
-        
+
         try:
             if rule.rule_type == "unity_catalog_lineage":
                 # Validate data lineage information
                 return self._validate_lineage(data, rule, databricks_params)
-            
+
             elif rule.rule_type == "delta_quality":
                 # Validate Delta Lake specific quality metrics
                 return self._validate_delta_quality(data, rule, databricks_params)
-            
+
             elif rule.rule_type == "workspace_permission":
                 # Validate workspace permissions for data access
                 return self._validate_permissions(data, rule, databricks_params)
-            
+
             else:
                 # Fallback to standard rule execution
                 return super().execute_rule(data, rule)
-        
+
         except Exception as e:
             end_time = time.time()
             execution_time = (end_time - start_time) * 1000
-            
+
             return ValidationResult(
                 rule_name=rule.name,
                 rule_type=rule.rule_type,
@@ -246,19 +269,25 @@ class DatabricksValidationEngine(PySparkValidationEngine):
                 message=f"Databricks rule execution failed: {str(e)}",
                 severity="error",
                 execution_time_ms=execution_time,
-                metadata={"engine": "databricks", "error": str(e), "databricks_runtime": self._databricks_runtime}
+                metadata={
+                    "engine": "databricks",
+                    "error": str(e),
+                    "databricks_runtime": self._databricks_runtime,
+                },
             )
-    
-    def _validate_lineage(self, data: DataFrame, rule: ValidationRule, params: Dict[str, Any]) -> ValidationResult:
+
+    def _validate_lineage(
+        self, data: DataFrame, rule: ValidationRule, params: Dict[str, Any]
+    ) -> ValidationResult:
         """Validate Unity Catalog lineage information."""
         start_time = time.time()
-        
+
         # This is a placeholder for lineage validation
         # In a real implementation, you would use Unity Catalog APIs
-        
+
         end_time = time.time()
         execution_time = (end_time - start_time) * 1000
-        
+
         return ValidationResult(
             rule_name=rule.name,
             rule_type=rule.rule_type,
@@ -269,19 +298,21 @@ class DatabricksValidationEngine(PySparkValidationEngine):
             message="Lineage validation completed",
             severity=rule.severity,
             execution_time_ms=execution_time,
-            metadata={"engine": "databricks", "rule_type": "lineage"}
+            metadata={"engine": "databricks", "rule_type": "lineage"},
         )
-    
-    def _validate_delta_quality(self, data: DataFrame, rule: ValidationRule, params: Dict[str, Any]) -> ValidationResult:
+
+    def _validate_delta_quality(
+        self, data: DataFrame, rule: ValidationRule, params: Dict[str, Any]
+    ) -> ValidationResult:
         """Validate Delta Lake specific quality metrics."""
         start_time = time.time()
-        
+
         # This is a placeholder for Delta quality validation
         # In a real implementation, you would check Delta Lake specific features
-        
+
         end_time = time.time()
         execution_time = (end_time - start_time) * 1000
-        
+
         return ValidationResult(
             rule_name=rule.name,
             rule_type=rule.rule_type,
@@ -292,19 +323,21 @@ class DatabricksValidationEngine(PySparkValidationEngine):
             message="Delta quality validation completed",
             severity=rule.severity,
             execution_time_ms=execution_time,
-            metadata={"engine": "databricks", "rule_type": "delta_quality"}
+            metadata={"engine": "databricks", "rule_type": "delta_quality"},
         )
-    
-    def _validate_permissions(self, data: DataFrame, rule: ValidationRule, params: Dict[str, Any]) -> ValidationResult:
+
+    def _validate_permissions(
+        self, data: DataFrame, rule: ValidationRule, params: Dict[str, Any]
+    ) -> ValidationResult:
         """Validate workspace permissions."""
         start_time = time.time()
-        
+
         # This is a placeholder for permission validation
         # In a real implementation, you would check Unity Catalog permissions
-        
+
         end_time = time.time()
         execution_time = (end_time - start_time) * 1000
-        
+
         return ValidationResult(
             rule_name=rule.name,
             rule_type=rule.rule_type,
@@ -315,10 +348,12 @@ class DatabricksValidationEngine(PySparkValidationEngine):
             message="Permission validation completed",
             severity=rule.severity,
             execution_time_ms=execution_time,
-            metadata={"engine": "databricks", "rule_type": "permissions"}
+            metadata={"engine": "databricks", "rule_type": "permissions"},
         )
-    
-    def create_databricks_job_config(self, validation_config_path: str) -> Dict[str, Any]:
+
+    def create_databricks_job_config(
+        self, validation_config_path: str
+    ) -> Dict[str, Any]:
         """Create Databricks job configuration for data validation."""
         return {
             "name": "data-validator-job",
@@ -328,58 +363,61 @@ class DatabricksValidationEngine(PySparkValidationEngine):
                 "num_workers": 2,
                 "spark_conf": {
                     "spark.sql.adaptive.enabled": "true",
-                    "spark.sql.adaptive.coalescePartitions.enabled": "true"
-                }
+                    "spark.sql.adaptive.coalescePartitions.enabled": "true",
+                },
             },
             "spark_python_task": {
                 "python_file": "dbfs:/databricks/scripts/run_validation.py",
                 "parameters": [
-                    "--config", validation_config_path,
-                    "--engine", "databricks"
-                ]
+                    "--config",
+                    validation_config_path,
+                    "--engine",
+                    "databricks",
+                ],
             },
-            "libraries": [
-                {
-                    "pypi": {
-                        "package": "data-validator[spark]"
-                    }
-                }
-            ],
+            "libraries": [{"pypi": {"package": "data-validator[spark]"}}],
             "timeout_seconds": 3600,
-            "max_retries": 2
+            "max_retries": 2,
         }
-    
+
     def get_cluster_info(self) -> Dict[str, Any]:
         """Get information about the current Databricks cluster."""
         cluster_info = {
-            "runtime_version": os.environ.get('DATABRICKS_RUNTIME_VERSION', 'unknown'),
+            "runtime_version": os.environ.get("DATABRICKS_RUNTIME_VERSION", "unknown"),
             "is_databricks_runtime": self._databricks_runtime,
-            "dbutils_available": self._dbutils is not None
+            "dbutils_available": self._dbutils is not None,
         }
-        
+
         if self._spark:
-            cluster_info.update({
-                "spark_version": self._spark.version,
-                "app_name": self._spark.sparkContext.appName,
-                "executor_memory": self._spark.conf.get("spark.executor.memory", "unknown"),
-                "driver_memory": self._spark.conf.get("spark.driver.memory", "unknown")
-            })
-        
+            cluster_info.update(
+                {
+                    "spark_version": self._spark.version,
+                    "app_name": self._spark.sparkContext.appName,
+                    "executor_memory": self._spark.conf.get(
+                        "spark.executor.memory", "unknown"
+                    ),
+                    "driver_memory": self._spark.conf.get(
+                        "spark.driver.memory", "unknown"
+                    ),
+                }
+            )
+
         return cluster_info
-    
+
     def log_to_databricks(self, message: str, level: str = "INFO") -> None:
         """Log messages using Databricks-specific logging."""
         # In Databricks, we can use standard Python logging which integrates with Databricks logs
         import logging
+
         logger = logging.getLogger("databricks_data_validator")
-        
+
         if level.upper() == "ERROR":
             logger.error(message)
         elif level.upper() == "WARNING":
             logger.warning(message)
         else:
             logger.info(message)
-    
+
     def disconnect(self) -> None:
         """Close Databricks connection."""
         # In Databricks runtime, we typically don't stop the Spark session
@@ -387,5 +425,5 @@ class DatabricksValidationEngine(PySparkValidationEngine):
         if not self._databricks_runtime and self._spark:
             self._spark.stop()
             self._spark = None
-        
+
         self._dbutils = None

--- a/src/data_validator/settings.py
+++ b/src/data_validator/settings.py
@@ -26,11 +26,11 @@ def _get_dbutils():
 class EnvSettings(BaseSettings):
     """Load configuration values from environment variables."""
 
-    config_file: str | None = None
-    engine__type: str | None = None
-    engine__connection_params: dict[str, Any] | None = None
-    engine__options: dict[str, Any] | None = None
-    dqx__enabled: bool | None = None
+    config_file: Optional[str] = None
+    engine__type: Optional[str] = None
+    engine__connection_params: Optional[dict[str, Any]] = None
+    engine__options: Optional[dict[str, Any]] = None
+    dqx__enabled: Optional[bool] = None
 
     class Config:
         env_prefix = "VALIDATOR_"

--- a/src/data_validator/settings.py
+++ b/src/data_validator/settings.py
@@ -1,0 +1,102 @@
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any
+
+import yaml
+from pydantic_settings import BaseSettings
+from pydantic import Field
+
+from .config import ValidationConfig
+
+
+def _get_dbutils():
+    """Return the dbutils instance if running on Databricks."""
+    try:
+        from IPython import get_ipython
+
+        ip = get_ipython()
+        if ip and "dbutils" in ip.user_ns:
+            return ip.user_ns["dbutils"]
+    except Exception:
+        pass
+    return None
+
+
+class EnvSettings(BaseSettings):
+    """Load configuration values from environment variables."""
+
+    config_file: str | None = None
+    engine__type: str | None = None
+    engine__connection_params: dict[str, Any] | None = None
+    engine__options: dict[str, Any] | None = None
+    dqx__enabled: bool | None = None
+
+    class Config:
+        env_prefix = "VALIDATOR_"
+        extra = "allow"
+        case_sensitive = False
+
+
+def merge_dicts(base: dict[str, Any], override: dict[str, Any]) -> dict[str, Any]:
+    """Recursively merge two dictionaries."""
+    for key, value in override.items():
+        if key in base and isinstance(base[key], dict) and isinstance(value, dict):
+            base[key] = merge_dicts(base[key], value)
+        else:
+            base[key] = value
+    return base
+
+
+def _expand_keys(data: dict[str, Any]) -> dict[str, Any]:
+    """Expand double-underscore keys into nested dictionaries."""
+    result: dict[str, Any] = {}
+    for key, value in data.items():
+        parts = key.split("__")
+        current = result
+        for part in parts[:-1]:
+            current = current.setdefault(part, {})
+        current[parts[-1]] = value
+    return result
+
+
+def load_config(
+    yaml_path: str | None = None,
+    *,
+    env_prefix: str = "VALIDATOR",
+    use_widgets: bool = False,
+) -> ValidationConfig:
+    """Load configuration from YAML with optional environment and widget overrides."""
+
+    settings = EnvSettings(_env_prefix=f"{env_prefix}_")
+    if yaml_path is None:
+        yaml_path = settings.config_file
+
+    widget_overrides: dict[str, Any] = {}
+    if use_widgets:
+        dbutils = _get_dbutils()
+        if dbutils is not None:
+            try:
+                widget_config = dbutils.widgets.get("config")
+                if widget_config:
+                    yaml_path = widget_config
+            except Exception:
+                pass
+            try:
+                widget_engine = dbutils.widgets.get("engine")
+                if widget_engine:
+                    widget_overrides.setdefault("engine", {})["type"] = widget_engine
+            except Exception:
+                pass
+
+    base_data: dict[str, Any] = {}
+    if yaml_path:
+        with open(Path(yaml_path), encoding="utf-8") as f:
+            base_data = yaml.safe_load(f) or {}
+
+    env_overrides = _expand_keys(
+        settings.model_dump(exclude={"config_file"}, exclude_none=True)
+    )
+    merged = merge_dicts(base_data, env_overrides)
+    merged = merge_dicts(merged, widget_overrides)
+    return ValidationConfig.from_dict(merged)

--- a/src/data_validator/validator.py
+++ b/src/data_validator/validator.py
@@ -5,6 +5,8 @@ Main DataValidator class that orchestrates validation operations.
 from typing import Any, Dict, List, Optional, Union
 from pathlib import Path
 
+from .settings import load_config
+
 from .config import ValidationConfig, ValidationRule
 from .engines import ValidationEngine, ValidationSummary, create_engine
 
@@ -12,166 +14,182 @@ from .engines import ValidationEngine, ValidationSummary, create_engine
 class DataValidator:
     """
     Main data validation orchestrator.
-    
+
     This class provides a high-level interface for validating data using
     YAML configuration files and multiple compute engines.
     """
-    
-    def __init__(self, config: Union[str, Path, Dict[str, Any], ValidationConfig]):
+
+    def __init__(
+        self,
+        config: Union[str, Path, Dict[str, Any], ValidationConfig],
+        *,
+        env_prefix: str = "VALIDATOR",
+        use_widgets: bool = False,
+    ):
+        """Initialize DataValidator with configuration.
+
+        Parameters
+        ----------
+        config:
+            Path to YAML configuration file or existing ``ValidationConfig`` object.
+        env_prefix:
+            Prefix for environment variable overrides when loading configuration.
+        use_widgets:
+            If ``True`` attempt to merge configuration values from Databricks widgets.
         """
-        Initialize DataValidator with configuration.
-        
-        Args:
-            config: Configuration as YAML file path, dictionary, or ValidationConfig object
-        """
+
         if isinstance(config, (str, Path)):
-            self.config = ValidationConfig.from_yaml(config)
+            self.config = load_config(
+                str(config), env_prefix=env_prefix, use_widgets=use_widgets
+            )
         elif isinstance(config, dict):
+            # Deprecated path: still supported for backwards compatibility
             self.config = ValidationConfig.from_dict(config)
         elif isinstance(config, ValidationConfig):
             self.config = config
         else:
             raise ValueError(f"Unsupported config type: {type(config)}")
-        
+
         self._engine: Optional[ValidationEngine] = None
         self._dqx_enabled = self.config.dqx.enabled
-    
+
     @property
     def engine(self) -> ValidationEngine:
         """Get or create validation engine."""
         if self._engine is None:
             self._engine = create_engine(self.config.engine)
         return self._engine
-    
-    def validate_table(self, 
-                      data: Any, 
-                      table_name: str,
-                      rules: Optional[List[ValidationRule]] = None) -> ValidationSummary:
+
+    def validate_table(
+        self, data: Any, table_name: str, rules: Optional[List[ValidationRule]] = None
+    ) -> ValidationSummary:
         """
         Validate a table using configured rules.
-        
+
         Args:
             data: Data to validate (DataFrame, table name, or file path)
             table_name: Name of the table being validated
             rules: Optional list of rules to use (defaults to config rules)
-        
+
         Returns:
             ValidationSummary with results
         """
         if rules is None:
             rules = self.config.get_enabled_rules(table_name)
-        
+
         with self.engine as eng:
             loaded_data = eng.load_data(data)
             summary = eng.execute_rules(loaded_data, rules, table_name)
-        
+
         # Integrate with DQX if enabled
         if self._dqx_enabled:
             summary = self._integrate_with_dqx(summary, table_name)
-        
+
         return summary
-    
-    def validate_all_tables(self, data_sources: Dict[str, Any]) -> Dict[str, ValidationSummary]:
+
+    def validate_all_tables(
+        self, data_sources: Dict[str, Any]
+    ) -> Dict[str, ValidationSummary]:
         """
         Validate multiple tables.
-        
+
         Args:
             data_sources: Dictionary mapping table names to data sources
-        
+
         Returns:
             Dictionary mapping table names to validation summaries
         """
         results = {}
-        
+
         with self.engine as eng:
             for table_name, data_source in data_sources.items():
                 rules = self.config.get_enabled_rules(table_name)
                 loaded_data = eng.load_data(data_source)
                 summary = eng.execute_rules(loaded_data, rules, table_name)
-                
+
                 # Integrate with DQX if enabled
                 if self._dqx_enabled:
                     summary = self._integrate_with_dqx(summary, table_name)
-                
+
                 results[table_name] = summary
-        
+
         return results
-    
-    def apply_filters(self, 
-                     data: Any, 
-                     table_name: str,
-                     rules: Optional[List[ValidationRule]] = None) -> Any:
+
+    def apply_filters(
+        self, data: Any, table_name: str, rules: Optional[List[ValidationRule]] = None
+    ) -> Any:
         """
         Apply validation rules as filters to clean data.
-        
+
         Args:
             data: Data to filter
             table_name: Name of the table being filtered
             rules: Optional list of rules to use (defaults to config rules)
-        
+
         Returns:
             Filtered data
         """
         if rules is None:
             rules = self.config.get_enabled_rules(table_name)
-        
+
         with self.engine as eng:
             filtered_data = eng.load_data(data)
-            
+
             for rule in rules:
                 if rule.enabled:
                     filtered_data = eng.apply_filter(filtered_data, rule)
-            
+
             # For DuckDB engine, convert back to DataFrame
             if self.config.engine.type == "duckdb" and isinstance(filtered_data, str):
                 # Get the DataFrame from the table
                 filtered_data = eng.get_dataframe(filtered_data)
-            
+
             return filtered_data
-    
-    def validate_with_dlt(self, 
-                         data: Any, 
-                         table_name: str,
-                         dlt_expectations: bool = True) -> ValidationSummary:
+
+    def validate_with_dlt(
+        self, data: Any, table_name: str, dlt_expectations: bool = True
+    ) -> ValidationSummary:
         """
         Validate data in Delta Live Tables context.
-        
+
         Args:
             data: Data to validate
             table_name: Name of the table
             dlt_expectations: Whether to create DLT expectations
-        
+
         Returns:
             ValidationSummary
         """
         summary = self.validate_table(data, table_name)
-        
+
         if dlt_expectations:
             self._create_dlt_expectations(summary, table_name)
-        
+
         return summary
-    
-    def get_validation_report(self, summaries: Union[ValidationSummary, Dict[str, ValidationSummary]]) -> Dict[str, Any]:
+
+    def get_validation_report(
+        self, summaries: Union[ValidationSummary, Dict[str, ValidationSummary]]
+    ) -> Dict[str, Any]:
         """
         Generate a comprehensive validation report.
-        
+
         Args:
             summaries: Single summary or dictionary of summaries
-        
+
         Returns:
             Formatted report dictionary
         """
         if isinstance(summaries, ValidationSummary):
             summaries = {"single_table": summaries}
-        
+
         report = {
             "validation_timestamp": self._get_timestamp(),
             "engine_type": self.config.engine.type,
             "total_tables": len(summaries),
             "overall_stats": self._calculate_overall_stats(summaries),
-            "table_results": {}
+            "table_results": {},
         }
-        
+
         for table_name, summary in summaries.items():
             report["table_results"][table_name] = {
                 "total_rules": summary.total_rules,
@@ -186,76 +204,91 @@ class DataValidator:
                         "passed": result.passed,
                         "success_rate": result.success_rate,
                         "message": result.message,
-                        "severity": result.severity
+                        "severity": result.severity,
                     }
                     for result in summary.results
-                ]
+                ],
             }
-        
+
         return report
-    
-    def _integrate_with_dqx(self, summary: ValidationSummary, table_name: str) -> ValidationSummary:
+
+    def _integrate_with_dqx(
+        self, summary: ValidationSummary, table_name: str
+    ) -> ValidationSummary:
         """Integrate validation results with DQX."""
         try:
             # This is a placeholder for DQX integration
             # In a real implementation, you would use the DQX package here
-            
+
             # Store metrics if configured
             if self.config.dqx.metrics_table:
                 self._store_dqx_metrics(summary, table_name)
-            
+
             # Store quarantined records if configured
             if self.config.dqx.quarantine_table:
                 self._store_quarantined_records(summary, table_name)
-            
+
         except Exception as e:
             # Don't fail validation if DQX integration fails
             print(f"Warning: DQX integration failed: {str(e)}")
-        
+
         return summary
-    
-    def _create_dlt_expectations(self, summary: ValidationSummary, table_name: str) -> None:
+
+    def _create_dlt_expectations(
+        self, summary: ValidationSummary, table_name: str
+    ) -> None:
         """Create Delta Live Tables expectations from validation results."""
         # This is a placeholder for DLT integration
         # In a real implementation, you would create DLT expectations here
         for result in summary.results:
             if not result.passed and result.severity == "error":
-                print(f"DLT Expectation: {result.rule_name} failed for table {table_name}")
-    
+                print(
+                    f"DLT Expectation: {result.rule_name} failed for table {table_name}"
+                )
+
     def _store_dqx_metrics(self, summary: ValidationSummary, table_name: str) -> None:
         """Store DQX metrics to configured table."""
         # Placeholder for storing metrics
         pass
-    
-    def _store_quarantined_records(self, summary: ValidationSummary, table_name: str) -> None:
+
+    def _store_quarantined_records(
+        self, summary: ValidationSummary, table_name: str
+    ) -> None:
         """Store quarantined records to configured table."""
         # Placeholder for storing quarantined records
         pass
-    
-    def _calculate_overall_stats(self, summaries: Dict[str, ValidationSummary]) -> Dict[str, Any]:
+
+    def _calculate_overall_stats(
+        self, summaries: Dict[str, ValidationSummary]
+    ) -> Dict[str, Any]:
         """Calculate overall statistics across all tables."""
         total_rules = sum(s.total_rules for s in summaries.values())
         total_passed = sum(s.passed_rules for s in summaries.values())
         total_failed = sum(s.failed_rules for s in summaries.values())
-        total_execution_time = sum(s.total_execution_time_ms for s in summaries.values())
-        
+        total_execution_time = sum(
+            s.total_execution_time_ms for s in summaries.values()
+        )
+
         return {
             "total_rules": total_rules,
             "total_passed": total_passed,
             "total_failed": total_failed,
-            "overall_success_rate": total_passed / total_rules if total_rules > 0 else 1.0,
-            "total_execution_time_ms": total_execution_time
+            "overall_success_rate": (
+                total_passed / total_rules if total_rules > 0 else 1.0
+            ),
+            "total_execution_time_ms": total_execution_time,
         }
-    
+
     def _get_timestamp(self) -> str:
         """Get current timestamp in ISO format."""
         from datetime import datetime
+
         return datetime.now().isoformat()
-    
+
     def __enter__(self):
         """Context manager entry."""
         return self
-    
+
     def __exit__(self, exc_type, exc_val, exc_tb):
         """Context manager exit."""
         if self._engine:

--- a/tests/test_settings.py
+++ b/tests/test_settings.py
@@ -1,0 +1,41 @@
+import os
+from pathlib import Path
+import yaml
+
+from data_validator.settings import load_config
+
+
+def test_env_var_override(tmp_path: Path) -> None:
+    config = {"version": "1.0", "engine": {"type": "pyspark"}, "tables": []}
+    path = tmp_path / "config.yaml"
+    path.write_text(yaml.dump(config))
+
+    os.environ["VALIDATOR_ENGINE__TYPE"] = "duckdb"
+    loaded = load_config(str(path))
+
+    assert loaded.engine.type == "duckdb"
+
+
+class DummyWidget:
+    def __init__(self, values):
+        self._values = values
+
+    def get(self, name):
+        return self._values.get(name, "")
+
+
+class DummyDbutils:
+    def __init__(self, values):
+        self.widgets = DummyWidget(values)
+
+
+def test_widget_override(monkeypatch, tmp_path: Path) -> None:
+    config = {"version": "1.0", "engine": {"type": "pyspark"}, "tables": []}
+    path = tmp_path / "config.yaml"
+    path.write_text(yaml.dump(config))
+
+    dbutils = DummyDbutils({"engine": "polars"})
+    monkeypatch.setattr("data_validator.settings._get_dbutils", lambda: dbutils)
+
+    loaded = load_config(str(path), use_widgets=True)
+    assert loaded.engine.type == "polars"


### PR DESCRIPTION
## Summary
- implement `EnvSettings` and `load_config` for YAML/environment/widget merges
- document configuration merging and environment overrides
- showcase merging in new example script
- sanitize databricks secret names
- test settings loader

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_687f7409bac8832692164c7d1ddbcb0c