### PR TITLE
Add CLI for local validation

### DIFF
--- a/CHECKLIST.md
+++ b/CHECKLIST.md
@@ -10,3 +10,4 @@
 - [x] Support env var overrides via Pydantic settings
 - [x] Merge config from Databricks widgets
 - [x] Add pipeline state management for idempotent restarts
+- [x] Add command line interface for local validation

--- a/README.md
+++ b/README.md
@@ -92,6 +92,14 @@ export VALIDATOR_ENGINE__CONNECTION_PARAMS__DATABASE=":memory:"
 validator = DataValidator("config.yaml")
 ```
 
+### 2.2 Command Line Usage
+
+You can run validations without writing any code using the `data-validator` CLI.
+
+```bash
+data-validator --config config.yaml --sources sources.yaml --output report.json
+```
+
 ### 3. Use as Data Filter
 
 ```python

--- a/docs/cli_usage.md
+++ b/docs/cli_usage.md
@@ -1,0 +1,15 @@
+# Command Line Usage
+
+The package provides a `data-validator` CLI for running validations without writing any code.
+
+```bash
+# Validate all tables defined in config and sources
+data-validator --config config.yaml --sources sources.yaml --output report.json
+
+# Validate a single table when data can be loaded by the engine
+data-validator --config config.yaml --table customers
+```
+
+The sources file should map table names to file paths or other data sources. It can be YAML or JSON.
+
+The generated report is written as JSON and is identical to the output produced by `DataValidator.get_validation_report`.

--- a/examples/cli_demo.py
+++ b/examples/cli_demo.py
@@ -1,0 +1,31 @@
+"""Demonstration of running the CLI programmatically."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+import subprocess
+
+
+HERE = Path(__file__).parent
+CONFIG = HERE / "sample_config.yaml"
+SOURCES = HERE / "sources.yaml"
+OUTPUT = HERE / "cli_report.json"
+
+
+def main() -> None:
+    cmd = [
+        "data-validator",
+        "--config",
+        str(CONFIG),
+        "--sources",
+        str(SOURCES),
+        "--output",
+        str(OUTPUT),
+    ]
+    subprocess.check_call(cmd)
+    print(json.loads(OUTPUT.read_text()))
+
+
+if __name__ == "__main__":
+    main()

--- a/examples/customers.csv
+++ b/examples/customers.csv
@@ -1,0 +1,4 @@
+id,name,email
+1,Alice,alice@example.com
+2,Bob,bob@example.com
+3,,charlie@example.com

--- a/examples/sources.yaml
+++ b/examples/sources.yaml
@@ -1,0 +1,1 @@
+customers: customers.csv

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,6 +12,7 @@ packages = [{include = "data_validator", from = "src"}]
 
 [tool.poetry.scripts]
 data-validator-job = "data_validator.databricks_job:main"
+data-validator = "data_validator.cli:main"
 
 [project]
 name = "data_validator"

--- a/src/data_validator/cli.py
+++ b/src/data_validator/cli.py
@@ -1,0 +1,74 @@
+"""Command line interface for running data validation locally."""
+
+from __future__ import annotations
+
+import argparse
+import json
+from pathlib import Path
+from typing import Any, Dict, Optional
+
+from . import DataValidator
+
+
+def _parse_args(argv: Optional[list[str]] = None) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        description="Run data validation using a YAML configuration file",
+    )
+    parser.add_argument(
+        "--config",
+        required=True,
+        help="Path to YAML validation configuration",
+    )
+    parser.add_argument(
+        "--sources",
+        help="Optional YAML file mapping table names to data sources",
+    )
+    parser.add_argument(
+        "--table",
+        help="Validate only a specific table from the configuration",
+    )
+    parser.add_argument(
+        "--output",
+        help="Path to write JSON validation report (prints to stdout if omitted)",
+    )
+    return parser.parse_args(argv)
+
+
+def run_cli(config_path: str, sources_path: Optional[str], table: Optional[str], output_path: Optional[str]) -> None:
+    """Execute validation based on CLI arguments."""
+    validator = DataValidator(config_path)
+
+    summaries: Dict[str, Any] = {}
+    if sources_path:
+        with open(sources_path, "r", encoding="utf-8") as f:
+            sources = json.load(f) if sources_path.endswith(".json") else __import__("yaml").safe_load(f)
+        if table:
+            data = sources.get(table)
+            if data is None:
+                raise ValueError(f"Table '{table}' not found in sources file")
+            summaries[table] = validator.validate_table(data, table)
+        else:
+            summaries = validator.validate_all_tables(sources)
+    else:
+        if table is None:
+            raise ValueError("--table must be provided when no sources file is given")
+        summaries[table] = validator.validate_table(table, table)
+
+    report = validator.get_validation_report(summaries)
+    output_data = json.dumps(report, indent=2)
+
+    if output_path:
+        out = Path(output_path)
+        out.parent.mkdir(parents=True, exist_ok=True)
+        out.write_text(output_data)
+    else:
+        print(output_data)
+
+
+def main(argv: Optional[list[str]] = None) -> None:
+    args = _parse_args(argv)
+    run_cli(args.config, args.sources, args.table, args.output)
+
+
+if __name__ == "__main__":  # pragma: no cover - entry point
+    main()

--- a/src/data_validator/cli.py
+++ b/src/data_validator/cli.py
@@ -41,7 +41,7 @@ def run_cli(config_path: str, sources_path: Optional[str], table: Optional[str],
     summaries: Dict[str, Any] = {}
     if sources_path:
         with open(sources_path, "r", encoding="utf-8") as f:
-            sources = json.load(f) if sources_path.endswith(".json") else __import__("yaml").safe_load(f)
+            sources = json.load(f) if sources_path.endswith(".json") else yaml.safe_load(f)
         if table:
             data = sources.get(table)
             if data is None:

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1,0 +1,55 @@
+import json
+import subprocess
+from pathlib import Path
+
+import pandas as pd
+import yaml
+
+
+def create_config(tmp: Path) -> Path:
+    config = {
+        "version": "1.0",
+        "engine": {"type": "duckdb", "connection_params": {"database": ":memory:"}},
+        "tables": [
+            {
+                "name": "customers",
+                "rules": [
+                    {"name": "id_not_null", "rule_type": "completeness", "column": "id", "severity": "error"}
+                ],
+            }
+        ],
+    }
+    path = tmp / "config.yaml"
+    with open(path, "w") as f:
+        yaml.dump(config, f)
+    return path
+
+
+def create_sources(tmp: Path) -> Path:
+    data_path = tmp / "customers.csv"
+    pd.DataFrame({"id": [1, None]}).to_csv(data_path, index=False)
+    sources_yaml = tmp / "sources.yaml"
+    with open(sources_yaml, "w") as f:
+        yaml.dump({"customers": str(data_path)}, f)
+    return sources_yaml
+
+
+def test_cli(tmp_path: Path) -> None:
+    config = create_config(tmp_path)
+    sources = create_sources(tmp_path)
+    output = tmp_path / "report.json"
+
+    subprocess.check_call([
+        "data-validator",
+        "--config",
+        str(config),
+        "--sources",
+        str(sources),
+        "--output",
+        str(output),
+    ])
+
+    assert output.exists()
+    report = json.loads(output.read_text())
+    assert report["total_tables"] == 1
+    assert "customers" in report["table_results"]


### PR DESCRIPTION
## Summary
- add `data-validator` command line tool
- document CLI usage
- showcase CLI usage in examples
- mention CLI in README
- add tests for CLI

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_688007d5fb9483268d55fd21d67f5a90