### PR TITLE
Add SQL rule validation with DuckDB

### DIFF
--- a/CHECKLIST.md
+++ b/CHECKLIST.md
@@ -11,3 +11,5 @@
 - [x] Merge config from Databricks widgets
 - [x] Add pipeline state management for idempotent restarts
 - [x] Add command line interface for local validation
+- [x] In-memory DuckDB engine with SQL rule enforcement
+- [x] Demo script and docs for SQL validation

--- a/README.md
+++ b/README.md
@@ -163,6 +163,19 @@ engine:
     memory_limit: "2GB"
 ```
 
+##### In-Memory SQL Validation
+You can enforce that all validation rules are portable SQL snippets by enabling
+`require_sql_rules`. This works well with the in-memory DuckDB engine.
+
+```yaml
+require_sql_rules: true
+engine:
+  type: "duckdb"
+  connection_params:
+    database: ":memory:"
+```
+Run the demo with `python examples/duckdb_sql_demo.py`.
+
 #### Polars Engine
 ```yaml
 engine:

--- a/docs/in_memory_duckdb.md
+++ b/docs/in_memory_duckdb.md
@@ -1,0 +1,13 @@
+# In-Memory DuckDB Validation
+
+This guide demonstrates how to run validations using an in-memory DuckDB instance where all validation rules are defined as SQL snippets. This approach is fully portable as only SQL is required.
+
+## Running the demo
+
+```bash
+python examples/duckdb_sql_demo.py
+```
+
+The demo loads `examples/customers.csv` and validates it using the configuration in `examples/sql_rules_config.yaml`.
+
+`require_sql_rules: true` in the configuration ensures every rule supplies a SQL `expression`.

--- a/examples/duckdb_sql_demo.py
+++ b/examples/duckdb_sql_demo.py
@@ -10,6 +10,15 @@ CONFIG_PATH = HERE / "sql_rules_config.yaml"
 DATA_PATH = HERE / "customers.csv"
 
 
+# Ensure the customers.csv file exists with sample data
+if not DATA_PATH.exists():
+    sample_data = pd.DataFrame({
+        "customer_id": [1, 2, 3],
+        "name": ["Alice", "Bob", "Charlie"],
+        "email": ["alice@example.com", "bob@example.com", "charlie@example.com"],
+        "age": [25, 30, 35]
+    })
+    sample_data.to_csv(DATA_PATH, index=False)
 def main() -> None:
     data = pd.read_csv(DATA_PATH)
     validator = DataValidator(CONFIG_PATH)

--- a/examples/duckdb_sql_demo.py
+++ b/examples/duckdb_sql_demo.py
@@ -1,0 +1,22 @@
+"""Demo script showcasing validation using in-memory DuckDB with SQL rules."""
+
+from pathlib import Path
+
+import pandas as pd
+from data_validator import DataValidator
+
+HERE = Path(__file__).parent
+CONFIG_PATH = HERE / "sql_rules_config.yaml"
+DATA_PATH = HERE / "customers.csv"
+
+
+def main() -> None:
+    data = pd.read_csv(DATA_PATH)
+    validator = DataValidator(CONFIG_PATH)
+    summary = validator.validate_table(data, "customers")
+    report = validator.get_validation_report(summary)
+    print(report)
+
+
+if __name__ == "__main__":
+    main()

--- a/examples/sql_rules_config.yaml
+++ b/examples/sql_rules_config.yaml
@@ -1,0 +1,25 @@
+version: "1.0"
+require_sql_rules: true
+engine:
+  type: "duckdb"
+  connection_params:
+    database: ":memory:"
+
+# Table-specific rules expressed as SQL snippets
+# Each expression should evaluate to number of failing rows
+
+tables:
+  - name: "customers"
+    rules:
+      - name: "id_not_null"
+        rule_type: "custom"
+        expression: "SELECT COUNT(*) FROM {table} WHERE id IS NULL"
+        severity: "error"
+      - name: "name_not_null"
+        rule_type: "custom"
+        expression: "SELECT COUNT(*) FROM {table} WHERE name IS NULL"
+        severity: "error"
+      - name: "email_valid"
+        rule_type: "custom"
+        expression: "SELECT COUNT(*) FROM {table} WHERE email NOT LIKE '%@%.'"
+        severity: "warning"

--- a/src/data_validator/cli.py
+++ b/src/data_validator/cli.py
@@ -7,6 +7,8 @@ import json
 from pathlib import Path
 from typing import Any, Dict, Optional
 
+import yaml
+
 from . import DataValidator
 
 
@@ -34,14 +36,21 @@ def _parse_args(argv: Optional[list[str]] = None) -> argparse.Namespace:
     return parser.parse_args(argv)
 
 
-def run_cli(config_path: str, sources_path: Optional[str], table: Optional[str], output_path: Optional[str]) -> None:
+def run_cli(
+    config_path: str,
+    sources_path: Optional[str],
+    table: Optional[str],
+    output_path: Optional[str],
+) -> None:
     """Execute validation based on CLI arguments."""
     validator = DataValidator(config_path)
 
     summaries: Dict[str, Any] = {}
     if sources_path:
         with open(sources_path, "r", encoding="utf-8") as f:
-            sources = json.load(f) if sources_path.endswith(".json") else yaml.safe_load(f)
+            sources = (
+                json.load(f) if sources_path.endswith(".json") else yaml.safe_load(f)
+            )
         if table:
             data = sources.get(table)
             if data is None:

--- a/src/data_validator/config.py
+++ b/src/data_validator/config.py
@@ -182,14 +182,14 @@ class ValidationConfig(BaseModel):
     def validate_sql_snippets(self) -> None:
         """Ensure that all enabled rules include an SQL expression."""
         for rule in self.global_rules:
-            if rule.enabled and not rule.expression:
-                raise ValueError(f"Rule '{rule.name}' must define an SQL expression")
+            if rule.enabled and (not rule.expression or not rule.expression.strip()):
+                raise ValueError(f"Rule '{rule.name}' must define a non-empty SQL expression")
 
         for table in self.tables:
             for rule in table.rules:
-                if rule.enabled and not rule.expression:
+                if rule.enabled and (not rule.expression or not rule.expression.strip()):
                     raise ValueError(
-                        f"Rule '{rule.name}' in table '{table.name}' must define an SQL expression"
+                        f"Rule '{rule.name}' in table '{table.name}' must define a non-empty SQL expression"
                     )
 
 

--- a/src/data_validator/config.py
+++ b/src/data_validator/config.py
@@ -126,6 +126,10 @@ class ValidationConfig(BaseModel):
     global_rules: List[ValidationRule] = Field(
         default_factory=list, description="Global validation rules"
     )
+    require_sql_rules: bool = Field(
+        default=False,
+        description="If True, all rules must provide an SQL expression for portability",
+    )
 
     @classmethod
     def from_yaml(cls, yaml_path: Union[str, Path]) -> "ValidationConfig":
@@ -174,6 +178,19 @@ class ValidationConfig(BaseModel):
                 rules.extend([rule for rule in table.rules if rule.enabled])
 
         return rules
+
+    def validate_sql_snippets(self) -> None:
+        """Ensure that all enabled rules include an SQL expression."""
+        for rule in self.global_rules:
+            if rule.enabled and not rule.expression:
+                raise ValueError(f"Rule '{rule.name}' must define an SQL expression")
+
+        for table in self.tables:
+            for rule in table.rules:
+                if rule.enabled and not rule.expression:
+                    raise ValueError(
+                        f"Rule '{rule.name}' in table '{table.name}' must define an SQL expression"
+                    )
 
 
 def _deep_merge(base: Dict[str, Any], overrides: Dict[str, Any]) -> Dict[str, Any]:

--- a/src/data_validator/validator.py
+++ b/src/data_validator/validator.py
@@ -52,6 +52,9 @@ class DataValidator:
         else:
             raise ValueError(f"Unsupported config type: {type(config)}")
 
+        if self.config.require_sql_rules:
+            self.config.validate_sql_snippets()
+
         self._engine: Optional[ValidationEngine] = None
         self._dqx_enabled = self.config.dqx.enabled
         self._state: Optional[PipelineState] = None

--- a/tests/test_sql_rules.py
+++ b/tests/test_sql_rules.py
@@ -1,0 +1,39 @@
+import pytest
+from data_validator.config import (
+    ValidationConfig,
+    ValidationRule,
+    TableConfig,
+    EngineConfig,
+)
+from data_validator import DataValidator
+
+
+def test_sql_snippet_validation():
+    rule = ValidationRule(
+        name="id_not_null",
+        rule_type="custom",
+        expression="SELECT COUNT(*) FROM {table} WHERE id IS NULL",
+        severity="error",
+    )
+    table = TableConfig(name="t", rules=[rule])
+    config = ValidationConfig(
+        require_sql_rules=True,
+        engine=EngineConfig(type="duckdb"),
+        tables=[table],
+    )
+
+    # Should not raise
+    DataValidator(config)
+
+
+def test_sql_snippet_missing_expression():
+    rule = ValidationRule(name="bad", rule_type="custom", severity="error")
+    table = TableConfig(name="t", rules=[rule])
+    config = ValidationConfig(
+        require_sql_rules=True,
+        engine=EngineConfig(type="duckdb"),
+        tables=[table],
+    )
+
+    with pytest.raises(ValueError):
+        DataValidator(config)


### PR DESCRIPTION
## Summary
- add require_sql_rules option to config
- validate SQL snippets when option enabled
- call validation in DataValidator initialization
- include example config and demo script using in-memory DuckDB
- document in-memory usage and update README
- fix CLI yaml import
- add unit tests for SQL rule enforcement
- update checklist

## Testing
- `pytest tests/test_sql_rules.py -q`
- `poetry run pytest -q` *(fails: PySpark missing)*

------
https://chatgpt.com/codex/tasks/task_e_6880c336737c8326b6e037641d4a0f70